### PR TITLE
Fix a bug where PCI id's of 0x80 or higher got sign extended in output

### DIFF
--- a/src/clinfo.c
+++ b/src/clinfo.c
@@ -383,7 +383,7 @@ printDeviceInfo(cl_uint d)
 		if (!had_error)
 			GET_PARAM(PCI_SLOT_ID_NV, slot);
 		if (!had_error)
-			snprintf(strbuf, bufsz, "%02x:%02x", bus, slot);
+			snprintf(strbuf, bufsz, "%02x:%02x.%x", bus, slot >> 3, slot & 7);
 		STR_PRINT("Device Topology (NV)", strbuf);
 	}
 


### PR DESCRIPTION
due to being cl_char in AMD's struct. 86:00.0 was shown as ffffff86:00.0
