### PR TITLE
Fix memory leak

### DIFF
--- a/src/clinfo.c
+++ b/src/clinfo.c
@@ -2328,6 +2328,7 @@ void checkNullCtxFromType()
 		}
 		printf("%s%s\n", def, strbuf);
 	}
+	free(devs);
 }
 
 /* check the behavior of NULL platform in clGetDeviceIDs (see checkNullGetDevices)


### PR DESCRIPTION
devs is locally dynamically allocated and must be freed.