### PR TITLE
Fix clinfo to work on 32-bit platforms

### DIFF
--- a/src/clinfo.c
+++ b/src/clinfo.c
@@ -1679,7 +1679,6 @@ struct device_info_traits dinfo_traits[] = {
 
 	{ CLINFO_BOTH, DINFO(CL_DEVICE_COMPILER_AVAILABLE, "Compiler Available", bool), NULL },
 	{ CLINFO_BOTH, DINFO(CL_DEVICE_LINKER_AVAILABLE, "Linker Available", bool), dev_is_12 },
-	{ CLINFO_BOTH, DINFO(CL_KERNEL_PREFERRED_WORK_GROUP_SIZE_MULTIPLE, "Preferred work group size multiple", wg), dev_has_compiler },
 	{ CLINFO_BOTH, DINFO(CL_DEVICE_WARP_SIZE_NV, "Warp size (NV)", int), dev_has_nv },
 	{ CLINFO_BOTH, DINFO(CL_DEVICE_WAVEFRONT_WIDTH_AMD, "Wavefront width (AMD)", int), dev_is_gpu_amd },
 	{ CLINFO_BOTH, DINFO(CL_DEVICE_MAX_NUM_SUB_GROUPS, "Max sub-groups per work group", int), dev_is_21 },

--- a/src/clinfo.c
+++ b/src/clinfo.c
@@ -1808,7 +1808,7 @@ struct device_info_traits dinfo_traits[] = {
 	 */
 
 	/* Profiling resolution */
-	{ CLINFO_BOTH, DINFO_SFX(CL_DEVICE_PROFILING_TIMER_RESOLUTION, "Profiling timer resolution", "ns", long), NULL },
+	{ CLINFO_BOTH, DINFO_SFX(CL_DEVICE_PROFILING_TIMER_RESOLUTION, "Profiling timer resolution", "ns", sz), NULL },
 	{ CLINFO_HUMAN, DINFO(CL_DEVICE_PROFILING_TIMER_OFFSET_AMD, "Profiling timer offset since Epoch (AMD)", time_offset), dev_has_amd },
 	{ CLINFO_RAW, DINFO(CL_DEVICE_PROFILING_TIMER_OFFSET_AMD, "Profiling timer offset since Epoch (AMD)", long), dev_has_amd },
 


### PR DESCRIPTION
Two problems were causing clinfo to crash on ARMv7 qemu with oclgrind OpenCL platform.

1. clGetDeviceInfo for CL_DEVICE_PROFILING_TIMER_RESOLUTION was erroneously using type "long" rather than type "size_t". This made no difference on 64-bit platforms, but is wrong for 32-bit.

2. clGetDeviceInfo was being called with CL_KERNEL_PREFERRED_WORK_GROUP_SIZE_MULTIPLE, which is not even a valid cl_device_info value--it is intended for clGetKernelWorkGroupInfo. On 32-bit oclgrind this produces an error, as it should. It was likely returning meaningless results on other platforms. I simply removed this line, as it is nonsensical.