### PR TITLE
Updated loader version detection to OpenCL 3.0.

### DIFF
--- a/src/clinfo.c
+++ b/src/clinfo.c
@@ -3139,6 +3139,7 @@ struct icd_loader_test {
 	{ 20, "clSVMAlloc" },
 	{ 21, "clGetHostTimer" },
 	{ 22, "clSetProgramSpecializationConstant" },
+	{ 30, "clSetContextDestructorCallback" },
 	{ 0, NULL }
 };
 


### PR DESCRIPTION
Hello,

This updates the loader version detection mechanism to avoid this issue:
```
ICD loader properties
  ICD loader Name                                 OpenCL ICD Loader
  ICD loader Vendor                               OCL Icd free software
  ICD loader Version                              2.2.13
  ICD loader Profile                              OpenCL 3.0
	NOTE:	your OpenCL library declares to support OpenCL 3.0,
		but it seems to support up to OpenCL 2.2 only.
	NOTE:	your OpenCL library only supports OpenCL 2.2,
		but some installed platforms support OpenCL 3.0.
		Programs using 3.0 features may crash
		or behave unexpectedly
```
and results in:
```
ICD loader properties
  ICD loader Name                                 OpenCL ICD Loader
  ICD loader Vendor                               OCL Icd free software
  ICD loader Version                              2.2.13
  ICD loader Profile                              OpenCL 3.0
```
Thanks,

Brice