### PR TITLE
Use RTLD_DEFAULT to unbreak on non-Linux

### DIFF
--- a/src/clinfo.c
+++ b/src/clinfo.c
@@ -15,7 +15,11 @@
 # define DL_MODULE GetModuleHandle("OpenCL")
 #else
 # include <dlfcn.h>
+#ifdef RTLD_DEFAULT
+# define DL_MODULE RTLD_DEFAULT
+#else
 # define DL_MODULE ((void*)0) /* This would be RTLD_DEFAULT */
+#endif
 #endif
 
 /* Load STDC format macros (PRI*), or define them


### PR DESCRIPTION
clinfo fails to look up available libOpenCL symbols and falls back to 1.0.
https://github.com/Oblomov/clinfo/blob/59d0daf898e48d76ccbb788acbba258fa0a8ba7c/src/clinfo.c#L3040-L3042
```
$ pkg install clinfo intel-compute-runtime
$ clinfo
[...]
        NOTE:   your OpenCL library declares to support OpenCL 2.2,
                but it seems to support up to OpenCL 1.0 only.
        NOTE:   your OpenCL library only supports OpenCL 1.0,
                but some installed platforms support OpenCL 3.0.
                Programs using 3.0 features may crash
                or behave unexpectedly

$ pkg info -x opencl ocl
opencl-2.2_2
ocl-icd-2.2.12
```

https://github.com/DragonFlyBSD/DragonFlyBSD/blob/v5.8.3/include/dlfcn.h#L59-L65
https://github.com/freebsd/freebsd/blob/releng/12.2/include/dlfcn.h#L62-L67
https://github.com/NetBSD/src/blob/2518280dc5e5/include/dlfcn.h#L84-L89
https://github.com/openbsd/src/blob/88eb9092f38b/include/dlfcn.h#L46-L51
https://github.com/illumos/illumos-gate/blob/4e0c5eff9af3/usr/src/head/dlfcn.h#L127-L137
