### PR TITLE
Bugfix: char-subscripts are treated as an error.

### DIFF
--- a/src/strbuf.h
+++ b/src/strbuf.h
@@ -125,7 +125,7 @@ static inline void strbuf_append_str(const char *what, struct _strbuf *str, cons
 static inline const char* skip_leading_ws(const char *str)
 {
 	const char *ret = str;
-	while (isspace(*ret)) ++ret;
+	while (isspace((unsigned char) *ret)) ++ret;
 	return ret;
 }
 


### PR DESCRIPTION
At least in Cygwin, isspace () will fail to compile as below if it takes char as an argument.

```
$ make
cc -g -pedantic -Werror -std=c99 -Wall -Wextra -I../OpenCL-Headers  -c -o clinfo.o src/clinfo.c
In file included from src/error.h:11,
                 from src/clinfo.c:35:
src/strbuf.h: In function ‘skip_leading_ws’:
src/strbuf.h:128:8: error: array subscript has type ‘char’ [-Werror=char-subscripts]
  128 |  while (isspace(*ret)) ++ret;
      |        ^~~~
cc1: all warnings being treated as errors
make: *** [<builtin>: clinfo.o] Error 1
```

For more details and recommendations for this error, see following:

* stackoverflow / 2012-04-02: [Warning: array subscript has type char](https://stackoverflow.com/a/60696378)