### PR TITLE
Fix oclIcdProps human-readable output.

### DIFF
--- a/src/clinfo.c
+++ b/src/clinfo.c
@@ -4447,6 +4447,8 @@ struct icdl_data oclIcdProps(const struct platform_list *plist, const struct opt
 				traits->pname : traits->sname);
 			loc.param.icdl = traits->param;
 
+			cur_sfx = empty_str;
+
 			reset_strbuf(&ret.str);
 			reset_strbuf(&ret.err_str);
 			icdl_info_str(&ret, &loc);


### PR DESCRIPTION
Without this commit, cur_sfx might be set when printing another property (e.g. "Platform Host timer resolution") and will remain set when printing the ICD loader properties. This manifested as an additional suffix in the output, as shown below:

  ICD loader properties
    ICD loader Name                                 OpenCL ICD Loaderns
    ICD loader Vendor                               OCL Icd free softwarens
    ICD loader Version                              2.3.2ns
    ICD loader Profile                              OpenCL 3.0ns