### PR TITLE
Adds support for vcpkg in Makefile.win

### DIFF
--- a/Makefile.win
+++ b/Makefile.win
@@ -1,19 +1,41 @@
+
+!IFNDEF PLATFORM
+PLATFORM=$(VSCMD_ARG_TGT_ARCH)
+!ENDIF
+
 # TODO FIXME find a better way to detect the directory to use
 # for OpenCL development files
+!IF ("$(OPENCLDIR)" == "") && EXIST("$(VCPKG_ROOT)\installed\$(PLATFORM)-windows\include\CL\cl.h")
+OPENCLDIR = $(VCPKG_ROOT)\installed\$(PLATFORM)-windows
+LIBS = OpenCL.lib
+LIBPATH32 = /LIBPATH:"$(OPENCLDIR)\lib"
+LIBPATH64 = /LIBPATH:"$(OPENCLDIR)\lib"
+!ENDIF
 !IF "$(OPENCLDIR)" == ""
 OPENCLDIR = $(INTELOCLSDKROOT)
+LIBS = OpenCL.lib
+LIBPATH32 = /LIBPATH:"$(OPENCLDIR)\lib\x86"
+LIBPATH64 = /LIBPATH:"$(OPENCLDIR)\lib\x64"
 !ENDIF
 !IF "$(OPENCLDIR)" == ""
 OPENCLDIR = $(AMDAPPSDKROOT)
+LIBS = libopenCL.a
+LIBPATH32 = /LIBPATH:"$(OPENCLDIR)\lib\x86"
+LIBPATH64 = /LIBPATH:"$(OPENCLDIR)\lib\x86_64"
 !ENDIF
 !IF "$(OPENCLDIR)" == ""
 OPENCLDIR = $(MAKEDIR)
+LIBS = libopenCL.a
+LIBPATH32 = /LIBPATH:"$(OPENCLDIR)\lib" /LIBPATH:"$(OPENCLDIR)\lib\x86"
+LIBPATH64 = /LIBPATH:"$(OPENCLDIR)\lib\x64" /LIBPATH:"$(OPENCLDIR)\lib\x86_64" /LIBPATH:"$(OPENCLDIR)\lib\x86_amd64"
 !ENDIF
 !IF "$(OPENCLDIR)" == ""
 OPENCLDIR = .
+LIBS = libopenCL.a
+LIBPATH32 = /LIBPATH:"$(OPENCLDIR)\lib" /LIBPATH:"$(OPENCLDIR)\lib\x86"
+LIBPATH64 = /LIBPATH:"$(OPENCLDIR)\lib\x64" /LIBPATH:"$(OPENCLDIR)\lib\x86_64" /LIBPATH:"$(OPENCLDIR)\lib\x86_amd64"
 !ENDIF
 !MESSAGE OpenCL dir: $(OPENCLDIR)
-
 
 HDR =	src/error.h \
 	src/ext.h \
@@ -27,7 +49,6 @@ HDR =	src/error.h \
 	src/strbuf.h
 
 CFLAGS = /GL /Ox /W4 /Zi /I"$(OPENCLDIR)\include" /nologo
-LIBS = libOpenCL.a
 
 # TODO there's most likely a better way to do the multiarch
 # switching
@@ -45,9 +66,6 @@ ARCH=32
 !ENDIF
 
 !MESSAGE Building for $(ARCH)-bit (processor architecture: $(PROCESSOR_ARCHITECTURE), platform: $(PLATFORM))
-
-LIBPATH32 = /LIBPATH:"$(OPENCLDIR)\lib" /LIBPATH:"$(OPENCLDIR)\lib\x86"
-LIBPATH64 = /LIBPATH:"$(OPENCLDIR)\lib\x64" /LIBPATH:"$(OPENCLDIR)\lib\x86_64" /LIBPATH:"$(OPENCLDIR)\lib\x86_amd64"
 
 # And since we can't do $(LIBPATH$(ARCH)) with nmake ...
 !IF "$(ARCH)" == "64"

--- a/fetch-opencl-vcpkg-win.cmd
+++ b/fetch-opencl-vcpkg-win.cmd
@@ -1,0 +1,36 @@
+REM call as fetch-opencl-vcpkg-win x86|x64
+@echo off
+SETLOCAL
+
+set VCPKG_VERSION="2024.10.21"
+
+if not "%~1" == "" (
+  set VCPKG_ARCH=%1
+) else if not defined PLATFORM (
+    set VCPKG_ARCH=%VSCMD_ARG_TGT_ARCH%
+) else (
+    set VCPKG_ARCH=%PLATFORM%
+)
+
+if NOT "%VCPKG_ARCH%" == "x64" (
+  if NOT "%VCPKG_ARCH%" == "x86" (
+    echo Bad argument: %VCPKG_ARCH%
+    echo %0 [x86^|x64]
+    exit /B 1
+  )
+)
+
+if not exist ".\vcpkg" (
+  git clone -b %VCPKG_VERSION%  --depth 1 https://github.com/microsoft/vcpkg .\vcpkg
+)
+
+if not exist ".\vcpkg\vcpkg.exe" (
+  cmd.exe /C .\vcpkg\bootstrap-vcpkg.bat -disableMetrics
+)
+
+echo Install OpenCL SDK
+.\vcpkg\vcpkg.exe install opencl --triplet="%VCPKG_ARCH%-windows"
+
+ENDLOCAL
+set VCPKG_ROOT=.\vcpkg
+


### PR DESCRIPTION
This PR adds support for VCPKG_ROOT variable in Makefile.win. It checks that OpenCL headers can be found before use. In case VCPKG_ROOT is not defined / or no OpenCL SDK is built with vcpkg, it falls back to the OPENCLDIR detection.

I also write a script to retrieve vcpkg.exe and build the OpenCL SDK dependency (for x64 or x86) and set VCPKG_ROOT.
So a build with vcpkg can be like that (in a Developer Command Prompt terminal) :
```
fetch-opencl-vcpkg-win.cmd
make.cmd
```

I have tested with Visual Studio 2022 for x86 and x64 architectures with VCPKG_ROOT.
I also tested with  the (now deprecated) AMDAPP / Intel OpenCL SDK, and the fetch-opencl-dev-win.cmd script (without VCPKG_ROOT environment variable).
