### PR TITLE
Fix Valgrind invalid read in platform device output

### DIFF
--- a/src/clinfo.c
+++ b/src/clinfo.c
@@ -3994,7 +3994,7 @@ void printPlatformDevices(const struct platform_list *plist, cl_uint p,
 
 		if (output->json) {
 			if (!output->brief) printf(" }");
-		} else if (output->detailed && d < pdata[p].ndevs - 1)
+		} else if (output->detailed && d < ndevs - 1)
 			puts("");
 
 


### PR DESCRIPTION
During a Valgrind run of clinfo, the following invalid read is reported:

==649372== Invalid read of size 4
==649372==    at 0x4017E65: printPlatformDevices (clinfo.c:3997)
==649372==    by 0x401823C: showDevices (clinfo.c:4051)
==649372==    by 0x401B185: main (clinfo.c:4849)
==649372==  Address 0x268bac60 is 16 bytes after a block of size 48 alloc'd
==649372==    at 0x487FBE3: calloc (vg_replace_malloc.c:1675)
==649372==    by 0x400A1D8: alloc_plist (clinfo.c:136)
==649372==    by 0x401AED8: main (clinfo.c:4806)
==649372==

printPlatformDevices used pdata[p].ndevs even though pdata already points to plist->pdata + p. That double indexing can read past the allocated array when p > 0, matching Valgrind's out-of-bounds report.